### PR TITLE
Fix index specification for arrays

### DIFF
--- a/ROS2/Bridge/Server_Python/bridge_py_s/bridge_py_s/bridge_py_s_node.py
+++ b/ROS2/Bridge/Server_Python/bridge_py_s/bridge_py_s/bridge_py_s_node.py
@@ -106,7 +106,7 @@ async def wss_recv():
             gNode.register_publisher(topic_name)
             publish_message = RACS2UserMsg()
             publish_message.body_data_length = len(recv_message) - 32
-            bytes_list = [elem.encode() for elem in recv_message[32:-1]]
+            bytes_list = [elem.encode() for elem in recv_message[32:]]
             publish_message.body_data = bytes_list
             if gNode is not None:
                 gNode.do_publish(topic_name, publish_message)


### PR DESCRIPTION
On the server side of the bridge, when storing received message in data for topic to be published, the tail of the received message array was not stored due to an index specification bug. This caused a "truncated message" error when decoding the message.
Therefore, the index specification of the array was corrected.