### PR TITLE
Fix message length in racs2_bridge_client.c

### DIFF
--- a/cFS/Bridge/Client_C/apps/racs2_bridge_client/fsw/src/racs2_bridge_client.c
+++ b/cFS/Bridge/Client_C/apps/racs2_bridge_client/fsw/src/racs2_bridge_client.c
@@ -318,7 +318,7 @@ void RACS2_BRIDGE_CLIENT_Init(void)
 
     CFE_SB_InitMsg(&RACS2_BRIDGE_CLIENT_HkTelemetryPkt,
                    RACS2_BRIDGE_CLIENT_HK_TLM_MID,
-                   CFS_CHAR_ARR_MSG_LNGTH, true);
+                   SAMPLE_APP_HK_TLM_LNGTH, true);
 
     CFE_EVS_SendEvent (SAMPLE_STARTUP_INF_EID, CFE_EVS_EventType_INFORMATION,
                "RACS2_BRIDGE_CLIENT App Initialized. Version %d.%d.%d.%d",


### PR DESCRIPTION
fix #6 
In Ubuntu 22.04 environment, a bug was observed that the bridge client app was not receiving messages from the sample talker app.

The message length during message packet initialization was specified to be longer than it should have been. As a result, the message pipe ID variable was also overwritten with zero, exceeding the packet definition area in memory. As a result, message reception processing was not working properly.

To correct the above problem, the message specified size was fixed.