### PR TITLE
RACS2 no longer drops initial messages

### DIFF
--- a/ROS2/Bridge/Server_Python/bridge_py_s/bridge_py_s/bridge_py_s_node.py
+++ b/ROS2/Bridge/Server_Python/bridge_py_s/bridge_py_s/bridge_py_s_node.py
@@ -12,6 +12,7 @@ from racs2_msg.msg import RACS2UserMsg
 # ------------------------------------------------------------------------------
 gNode = None
 
+gLogger = rclpy.logging.get_logger("RACS2Bridge")
 
 class _BridgePyS(Node):
 
@@ -23,8 +24,8 @@ class _BridgePyS(Node):
 
         self.wss_uri = self.get_parameter("wss_uri").value
         self.wss_port = self.get_parameter("wss_port").value
-        print("Parameter(wss_uri) : " + self.wss_uri)
-        print("Parameter(wss_port) : " + str(self.wss_port))
+        self.get_logger().info("Parameter(wss_uri) : " + self.wss_uri)
+        self.get_logger().info("Parameter(wss_port) : " + str(self.wss_port))
 
         # Subscription
         self.subscription = self.create_subscription(
@@ -52,25 +53,22 @@ class _BridgePyS(Node):
             try:
                 await wss_send(gWebSocket, msg)
             except Exception as e:
-                print(str(e))
+                self.get_logger().error(f"Failed to send message: {e}")
                 gWebSocket = None
 
     def do_publish(self, topic_name, aMessage):
         if not topic_name in self.publisher_info:
-            print(f"Publisher for topic[{topic_name}] does not exit")
+            self.get_logger().error(f"Publisher for topic[{topic_name}] does not exit")
             return
         self.publisher_info[topic_name].publish(aMessage)
 
     def register_publisher(self, topic_name):
-        if len(self.publisher_info) == 0:
-            self.publisher_info[topic_name] = self.create_publisher(
-                RACS2UserMsg, topic_name, 10)
-            print(f"Create publisher for topic[{topic_name}]")
-        else:
-            if not topic_name in self.publisher_info:
-                self.publisher_info[topic_name] = self.create_publisher(
-                    RACS2UserMsg, topic_name, 10)
+        if topic_name in self.publisher_info:
+            return
 
+        self.publisher_info[topic_name] = self.create_publisher(
+            RACS2UserMsg, topic_name, 10)
+        self.get_logger().info(f"Created publisher for topic[{topic_name}]")
 
 async def spin_once(aNode):
     rclpy.spin_once(aNode, timeout_sec=0)
@@ -87,22 +85,22 @@ gWebSocket = None
 
 
 async def wss_send(websocket, message):
-    print('[RACS2 Bridge] wss_send')
+    gLogger.info('wss_send')
     await websocket.send(message)
 
 
 async def wss_recv():
     global gWebSocket
     if (gWebSocket is None):
-        print("WebSocket is error.")
+        gLogger.error("WebSocket is error.")
         return
     websocket = gWebSocket
     while True:
         try:
             recv_message = await websocket.recv()
-            print(f'WssRecv: {recv_message}')
+            gLogger.info(f'WssRecv: {recv_message}')
             topic_name = recv_message[0:32].decode()
-            print(f"topic name = {topic_name}")
+            gLogger.info(f"topic name = {topic_name}")
             gNode.register_publisher(topic_name)
             publish_message = RACS2UserMsg()
             publish_message.body_data_length = len(recv_message) - 32
@@ -111,31 +109,31 @@ async def wss_recv():
             if gNode is not None:
                 gNode.do_publish(topic_name, publish_message)
         except websockets.ConnectionClosedOK:
-            print("Error: websockets")
+            gLogger.error("Error: websockets")
             break
 
 
 async def wss_accept(websocket, path):
-    print('[RACS2 Bridge] wss_accept | path: %s' % path)
+    gLogger.info('wss_accept | path: %s' % path)
     global gWebSocket
     gWebSocket = websocket
 
     async for message in websocket:
-        print('Recv: %s' % message)
+        gLogger.info('Recv: %s' % message)
         # for confirmation
         # await websocket.send( "server accepted.")
         await wss_recv()
 
 
 async def wss_run(aNode):
-    print('[RACS2 Bridge] wss_run')
+    gLogger.info('wss_run')
     async with websockets.serve(wss_accept, aNode.wss_uri, aNode.wss_port):
         await asyncio.Future()
 
 
 # ----------------------------------------------------------
 def main(args=None):
-    print('[RACS2 Bridge] bridge_py_s - main')
+    gLogger.info('bridge_py_s - main')
     rclpy.init(args=args)
 
     bridge_py_s = _BridgePyS()


### PR DESCRIPTION
I noticed that I had to send multiple messages before seeing that message on a ROS topic. This PR solves that and also changes print statements in the ROS2 python server to use ROS logging (logs are flushed in realtime to the console this way).

Tested communication from RACS2->ROS2 in my sample application and also tested the opposite direction by calling `ros2 topic pub /RACS2Bridge racs2_msg/msg/RACS2UserMsg '{cfs_message_id: 234 }' -1`