### PR TITLE
Standardize websocket body length framing

### DIFF
--- a/Document/HowToExchangeMessages.md
+++ b/Document/HowToExchangeMessages.md
@@ -1,5 +1,13 @@
 # How to convert messages
 
+## WebSocket transport format
+
+Both ROS2->cFS and cFS->ROS2 use the binary WebSocket packet format defined in `WebSocketProtocol.md`:
+
+`[32-byte header] + [4-byte big-endian body_data_length] + [body_data]`
+
+The WebSocket frame must contain exactly `36 + body_data_length` bytes, and `body_data_length` must not exceed 128. The application-side `body_data_length` fields shown below are converted to and from this 4-byte wire representation by the bridge.
+
 ## ROS2->cFS
 
 ### ROS2 side

--- a/Document/WebSocketProtocol.md
+++ b/Document/WebSocketProtocol.md
@@ -1,0 +1,29 @@
+# WebSocket packet format
+
+RACS2 uses the same binary WebSocket packet format in both directions between the ROS2 bridge and the cFS bridge.
+
+| Offset | Size | Field |
+| --- | ---: | --- |
+| 0 | 32 bytes | Header |
+| 32 | 4 bytes | `body_data_length`, unsigned big-endian |
+| 36 | `body_data_length` bytes | Body data |
+
+The body may contain from 0 to 128 bytes. The total WebSocket frame size is therefore exactly `36 + body_data_length` bytes.
+
+## Header
+
+The 32-byte header depends on the direction:
+
+- ROS2 to cFS: bytes 0-1 contain the cFS destination message ID in big-endian order. The remaining header bytes are reserved and currently zero-filled.
+- cFS to ROS2: the header contains the ROS2 topic name, zero-padded to 32 bytes.
+
+## Length validation
+
+Receivers must reject a frame when any of these conditions is true:
+
+- the frame is shorter than 36 bytes;
+- `body_data_length` is greater than 128;
+- the actual frame size is not exactly `36 + body_data_length` bytes;
+- the WebSocket message is not binary.
+
+The `body_data_length` field used inside ROS2/cFS application messages is an application-side representation. On the WebSocket wire, the length is always encoded as the 4-byte big-endian field described above.

--- a/Example/Case.1/README.md
+++ b/Example/Case.1/README.md
@@ -115,4 +115,5 @@ This file contains a description of the RACS2 Example. The following movements c
 ## How to exchange messages
 
 - See `Document/HowToExchangeMessages.md`.
+- Case.1 uses the common binary WebSocket format in `Document/WebSocketProtocol.md`: a 32-byte topic-name header, a 4-byte big-endian body length, and exactly that many body bytes.
 

--- a/Example/Case.2/README.md
+++ b/Example/Case.2/README.md
@@ -115,4 +115,5 @@ This file contains a description of the RACS2 Example. The following movements c
 ## How to exchange messages
 
 - See `Document/HowToExchangeMessages.md`.
+- Case.2 uses the common binary WebSocket format in `Document/WebSocketProtocol.md`: a 32-byte header containing the cFS destination message ID, a 4-byte big-endian body length, and exactly that many body bytes.
 

--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ It must be built separately for both cFS and ROS 2. For detailed procedure, plea
 ## How to exchange messages
 
 - See `Document/HowToExchangeMessages.md`.
+- The binary WebSocket packet format is defined in `Document/WebSocketProtocol.md`.
 
 ## Reference
 

--- a/ROS2/Bridge/Server_Python/bridge_py_s/bridge_py_s/bridge_py_s_node.py
+++ b/ROS2/Bridge/Server_Python/bridge_py_s/bridge_py_s/bridge_py_s_node.py
@@ -7,12 +7,14 @@ import asyncio
 import websockets
 
 from racs2_msg.msg import RACS2UserMsg
+from bridge_py_s.protocol import ProtocolError, pack_frame, unpack_frame
 
 
 # ------------------------------------------------------------------------------
 gNode = None
 
 gLogger = rclpy.logging.get_logger("RACS2Bridge")
+
 
 class _BridgePyS(Node):
 
@@ -40,13 +42,20 @@ class _BridgePyS(Node):
 
     # ROS2 Topic
     async def subscription_callback(self, aMsg):
-        # self.get_logger().info('Recv data')
-        bMessage = RACS2UserMsg()
-        bMessage.body_data = aMsg.body_data
-        # fill message id into header
+        body = b''.join(aMsg.body_data)
+        if aMsg.body_data_length != len(body):
+            self.get_logger().error(
+                "body_data_length does not match the ROS2 message body"
+            )
+            return
+
         msg_header = bytearray(32)
         msg_header[0:2] = aMsg.cfs_message_id.to_bytes(2, 'big')
-        msg = msg_header+b''.join(aMsg.body_data)
+        try:
+            msg = pack_frame(msg_header, body)
+        except ProtocolError as e:
+            self.get_logger().error(f"Invalid bridge message: {e}")
+            return
 
         global gWebSocket
         if gWebSocket is not None:
@@ -57,7 +66,7 @@ class _BridgePyS(Node):
                 gWebSocket = None
 
     def do_publish(self, topic_name, aMessage):
-        if not topic_name in self.publisher_info:
+        if topic_name not in self.publisher_info:
             self.get_logger().error(f"Publisher for topic[{topic_name}] does not exit")
             return
         self.publisher_info[topic_name].publish(aMessage)
@@ -69,6 +78,7 @@ class _BridgePyS(Node):
         self.publisher_info[topic_name] = self.create_publisher(
             RACS2UserMsg, topic_name, 10)
         self.get_logger().info(f"Created publisher for topic[{topic_name}]")
+
 
 async def spin_once(aNode):
     rclpy.spin_once(aNode, timeout_sec=0)
@@ -93,13 +103,18 @@ async def wss_recv(websocket):
     global gWebSocket
     gWebSocket = websocket
 
-    if (gWebSocket is None):
+    if gWebSocket is None:
         gLogger.error("WebSocket is error.")
         return
     try:
         async for recv_message in websocket:
-            gLogger.info(f'WssRecv: {recv_message}')
-            topic_name = recv_message[0:32].decode()
+            try:
+                header, body = unpack_frame(recv_message)
+                topic_name = header.split(b'\0', 1)[0].decode('utf-8')
+            except (ProtocolError, UnicodeDecodeError) as e:
+                gLogger.error(f"Invalid websocket frame: {e}")
+                continue
+
             gLogger.info(f"topic name = {topic_name}")
 
             if gNode is None:
@@ -107,9 +122,8 @@ async def wss_recv(websocket):
                 continue
             gNode.register_publisher(topic_name)
             publish_message = RACS2UserMsg()
-            publish_message.body_data_length = len(recv_message) - 32
-            bytes_list = [bytes([elem]) for elem in recv_message[32:]]
-            publish_message.body_data = bytes_list
+            publish_message.body_data_length = len(body)
+            publish_message.body_data = [bytes([elem]) for elem in body]
             gNode.do_publish(topic_name, publish_message)
     except websockets.ConnectionClosedOK:
         gLogger.warning("Websocket closed properly.")

--- a/ROS2/Bridge/Server_Python/bridge_py_s/bridge_py_s/bridge_py_s_node.py
+++ b/ROS2/Bridge/Server_Python/bridge_py_s/bridge_py_s/bridge_py_s_node.py
@@ -7,7 +7,7 @@ import asyncio
 import websockets
 
 from racs2_msg.msg import RACS2UserMsg
-from bridge_py_s.protocol import ProtocolError, pack_frame, unpack_frame
+from bridge_py_s.protocol import HEADER_LENGTH, ProtocolError, pack_frame, unpack_frame
 
 
 # ------------------------------------------------------------------------------
@@ -49,7 +49,7 @@ class _BridgePyS(Node):
             )
             return
 
-        msg_header = bytearray(32)
+        msg_header = bytearray(HEADER_LENGTH)
         msg_header[0:2] = aMsg.cfs_message_id.to_bytes(2, 'big')
         try:
             msg = pack_frame(msg_header, body)
@@ -66,7 +66,7 @@ class _BridgePyS(Node):
                 gWebSocket = None
 
     def do_publish(self, topic_name, aMessage):
-        if topic_name not in self.publisher_info:
+        if not topic_name in self.publisher_info:
             self.get_logger().error(f"Publisher for topic[{topic_name}] does not exit")
             return
         self.publisher_info[topic_name].publish(aMessage)
@@ -103,7 +103,7 @@ async def wss_recv(websocket):
     global gWebSocket
     gWebSocket = websocket
 
-    if gWebSocket is None:
+    if (gWebSocket is None):
         gLogger.error("WebSocket is error.")
         return
     try:

--- a/ROS2/Bridge/Server_Python/bridge_py_s/bridge_py_s/protocol.py
+++ b/ROS2/Bridge/Server_Python/bridge_py_s/bridge_py_s/protocol.py
@@ -1,0 +1,43 @@
+HEADER_LENGTH = 32
+BODY_LENGTH_FIELD_LENGTH = 4
+MAX_BODY_LENGTH = 128
+FRAME_PREFIX_LENGTH = HEADER_LENGTH + BODY_LENGTH_FIELD_LENGTH
+
+
+class ProtocolError(ValueError):
+    pass
+
+
+def pack_frame(header, body):
+    header = bytes(header)
+    body = bytes(body)
+
+    if len(header) != HEADER_LENGTH:
+        raise ProtocolError(f"header must be {HEADER_LENGTH} bytes")
+    if len(body) > MAX_BODY_LENGTH:
+        raise ProtocolError(f"body exceeds {MAX_BODY_LENGTH} bytes")
+
+    return header + len(body).to_bytes(BODY_LENGTH_FIELD_LENGTH, byteorder="big") + body
+
+
+def unpack_frame(frame):
+    if not isinstance(frame, (bytes, bytearray, memoryview)):
+        raise ProtocolError("websocket frame must be binary")
+
+    frame = bytes(frame)
+    if len(frame) < FRAME_PREFIX_LENGTH:
+        raise ProtocolError("websocket frame is shorter than the protocol prefix")
+
+    body_length = int.from_bytes(
+        frame[HEADER_LENGTH:FRAME_PREFIX_LENGTH], byteorder="big"
+    )
+    if body_length > MAX_BODY_LENGTH:
+        raise ProtocolError(f"declared body length exceeds {MAX_BODY_LENGTH} bytes")
+
+    expected_length = FRAME_PREFIX_LENGTH + body_length
+    if len(frame) != expected_length:
+        raise ProtocolError(
+            f"frame length {len(frame)} does not match declared body length {body_length}"
+        )
+
+    return frame[:HEADER_LENGTH], frame[FRAME_PREFIX_LENGTH:]

--- a/ROS2/Bridge/Server_Python/bridge_py_s/test/test_protocol.py
+++ b/ROS2/Bridge/Server_Python/bridge_py_s/test/test_protocol.py
@@ -1,0 +1,60 @@
+import pytest
+
+from bridge_py_s.protocol import (
+    BODY_LENGTH_FIELD_LENGTH,
+    FRAME_PREFIX_LENGTH,
+    HEADER_LENGTH,
+    MAX_BODY_LENGTH,
+    ProtocolError,
+    pack_frame,
+    unpack_frame,
+)
+
+
+@pytest.mark.parametrize("body_length", [0, 1, 127, 128])
+def test_frame_round_trip(body_length):
+    header = bytes(range(HEADER_LENGTH))
+    body = bytes(i % 256 for i in range(body_length))
+
+    frame = pack_frame(header, body)
+    parsed_header, parsed_body = unpack_frame(frame)
+
+    assert parsed_header == header
+    assert parsed_body == body
+    assert len(frame) == FRAME_PREFIX_LENGTH + body_length
+    assert int.from_bytes(
+        frame[HEADER_LENGTH:HEADER_LENGTH + BODY_LENGTH_FIELD_LENGTH], byteorder="big"
+    ) == body_length
+
+
+def test_pack_rejects_oversized_body():
+    with pytest.raises(ProtocolError):
+        pack_frame(bytes(HEADER_LENGTH), bytes(MAX_BODY_LENGTH + 1))
+
+
+def test_unpack_rejects_short_frame():
+    with pytest.raises(ProtocolError):
+        unpack_frame(bytes(FRAME_PREFIX_LENGTH - 1))
+
+
+def test_unpack_rejects_declared_length_mismatch():
+    frame = bytes(HEADER_LENGTH) + (3).to_bytes(4, byteorder="big") + b"ab"
+
+    with pytest.raises(ProtocolError):
+        unpack_frame(frame)
+
+
+def test_unpack_rejects_oversized_declared_length():
+    frame = (
+        bytes(HEADER_LENGTH)
+        + (MAX_BODY_LENGTH + 1).to_bytes(4, byteorder="big")
+        + bytes(MAX_BODY_LENGTH + 1)
+    )
+
+    with pytest.raises(ProtocolError):
+        unpack_frame(frame)
+
+
+def test_unpack_rejects_text_frame():
+    with pytest.raises(ProtocolError):
+        unpack_frame("not-binary")

--- a/cFS/Bridge/Client_C/apps/racs2_bridge_client/fsw/src/racs2_bridge_client.c
+++ b/cFS/Bridge/Client_C/apps/racs2_bridge_client/fsw/src/racs2_bridge_client.c
@@ -35,7 +35,8 @@ static CFE_EVS_BinFilter_t  SAMPLE_EventFilters[] =
 
 pthread_mutex_t g_bridge_msg_pkt_mutex;
 uint8_t g_should_send_msg_pkt = 0;
-uint8_t g_bridge_msg_pkt[BRIDGE_HEADER_LNGTH+BODY_DATA_MAX_LNGTH];
+uint8_t g_bridge_msg_pkt[RACS2_BRIDGE_MSG_LNGTH];
+size_t g_bridge_msg_pkt_length = 0;
 
 /* -- websocket settings -------- */
 #include <libwebsockets.h>
@@ -49,10 +50,25 @@ enum protocols
 };
 
 #define EXAMPLE_RX_BUFFER_BYTES (256)
-#define RACS2_BRIDGE_HEADER_LENGTH 32
 #define RACS2_BRIDGE_DEST_MSGID_NUM 16
 uint8_t registerd_msgid_num = 0;
 uint16 dest_message_id_list[RACS2_BRIDGE_DEST_MSGID_NUM] = {0};
+
+static uint32 RACS2_BRIDGE_ReadBodyDataLength(const uint8 *field)
+{
+    return ((uint32)field[0] << 24) |
+           ((uint32)field[1] << 16) |
+           ((uint32)field[2] << 8) |
+           (uint32)field[3];
+}
+
+static void RACS2_BRIDGE_WriteBodyDataLength(uint8 *field, uint32 body_data_length)
+{
+    field[0] = (uint8)(body_data_length >> 24);
+    field[1] = (uint8)(body_data_length >> 16);
+    field[2] = (uint8)(body_data_length >> 8);
+    field[3] = (uint8)body_data_length;
+}
 
 static int callback_example( struct lws *wsi, enum lws_callback_reasons reason, void *user, void *in, size_t len )
 {
@@ -67,20 +83,36 @@ static int callback_example( struct lws *wsi, enum lws_callback_reasons reason, 
             break;
 
         case LWS_CALLBACK_CLIENT_RECEIVE:
+        {
+            uint8 *recv_data = (uint8 *)in;
+            uint32 body_data_length;
+
             lwsl_user( "case LWS_CALLBACK_CLIENT_RECEIVE: \n" ) ;
-            lwsl_user( "[Recv]: %s\n", (char*)in ) ;
             lwsl_user( "[Recv]: data len = %ld\n", len ) ;
 
-            // === send message =========================
-            char *hello = "Hello";
-            if (!strncmp((char*)in, hello, 1))
+            if (len == 5 && memcmp(in, "Hello", 5) == 0)
             {
-                // OS_printf("[Recv]: %s\n", (char*)in);
                 break;
             }
+
+            if (len < BODY_DATA_OFFSET)
+            {
+                OS_printf("RACS2_BRIDGE_CLIENT: invalid websocket packet length: %lu\n", (unsigned long)len);
+                break;
+            }
+
+            body_data_length = RACS2_BRIDGE_ReadBodyDataLength(recv_data + BRIDGE_HEADER_LNGTH);
+            if (body_data_length > BODY_DATA_MAX_LNGTH ||
+                len != (size_t)(BODY_DATA_OFFSET + body_data_length))
+            {
+                OS_printf("RACS2_BRIDGE_CLIENT: invalid websocket body length: declared=%lu, packet=%lu\n",
+                          (unsigned long)body_data_length, (unsigned long)len);
+                break;
+            }
+
             // Get message ID from header
-            uint16_t id_seg1 = ((uint8_t*)in)[0];
-            uint16_t id_seg2 = ((uint8_t*)in)[1];
+            uint16_t id_seg1 = recv_data[0];
+            uint16_t id_seg2 = recv_data[1];
             uint16_t message_id = id_seg1 << 8 | id_seg2;
             OS_printf("RACS2_BRIDGE_CLIENT: dest cFS message ID : 0x%x\n", message_id);
             // if (is_new_msgid(message_id)) {
@@ -89,12 +121,9 @@ static int callback_example( struct lws *wsi, enum lws_callback_reasons reason, 
             //     OS_printf("RACS2_BRIDGE_CLIENT: CFE_SB_InitMsg for MsgId[%x]\n\n\n\n\n\n\n", message_id);
             // }
             CFE_SB_InitMsg(&RACS2_UserMsgPkt, message_id, RACS2_USER_MSG_LNGTH, true);
-            // Set body data length
-            uint8_t body_data_length = len - RACS2_BRIDGE_HEADER_LENGTH;
-            RACS2_UserMsgPkt.body_data_length = body_data_length;
-            OS_printf("RACS2_BRIDGE_CLIENT: body data length : %d\n", body_data_length);
-            // Copy body data
-            memcpy(RACS2_UserMsgPkt.body_data, (uint8_t*)in + RACS2_BRIDGE_HEADER_LENGTH, body_data_length);
+            RACS2_UserMsgPkt.body_data_length = (uint8)body_data_length;
+            OS_printf("RACS2_BRIDGE_CLIENT: body data length : %lu\n", (unsigned long)body_data_length);
+            memcpy(RACS2_UserMsgPkt.body_data, recv_data + BODY_DATA_OFFSET, body_data_length);
             // Send message
             CFE_SB_TimeStampMsg((CFE_SB_Msg_t *) &RACS2_UserMsgPkt);
             int32 status = CFE_SB_SendMsg((CFE_SB_Msg_t *) &RACS2_UserMsgPkt);
@@ -109,8 +138,8 @@ static int callback_example( struct lws *wsi, enum lws_callback_reasons reason, 
                 OS_printf("RACS2_BRIDGE_CLIENT: Error: sending is failed. \n");
             }
 
-
             break;
+        }
 
         case LWS_CALLBACK_CLIENT_WRITEABLE:
         {
@@ -119,7 +148,7 @@ static int callback_example( struct lws *wsi, enum lws_callback_reasons reason, 
             pthread_mutex_lock(&g_bridge_msg_pkt_mutex);
             if (g_should_send_msg_pkt)
             {
-              lws_write( wsi, g_bridge_msg_pkt, BRIDGE_HEADER_LNGTH+BODY_DATA_MAX_LNGTH, LWS_WRITE_BINARY );
+              lws_write( wsi, g_bridge_msg_pkt, g_bridge_msg_pkt_length, LWS_WRITE_BINARY );
               g_should_send_msg_pkt = 0;
             }
             pthread_mutex_unlock(&g_bridge_msg_pkt_mutex);
@@ -356,13 +385,25 @@ void RACS2_BRIDGE_CLIENT_ProcessCommandPacket(void)
             OS_printf("RACS2_BRIDGE_CLIENT: ros2_topic_name = %s\n", tmp_ptr->ros2_topic_name);
             OS_printf("RACS2_BRIDGE_CLIENT: body_data_length = %d\n", tmp_ptr->body_data_length);
 
+            if (tmp_ptr->body_data_length > BODY_DATA_MAX_LNGTH)
+            {
+                OS_printf("RACS2_BRIDGE_CLIENT: body data exceeds maximum length: %d\n",
+                          tmp_ptr->body_data_length);
+                break;
+            }
+
             pthread_mutex_lock(&g_bridge_msg_pkt_mutex);
             // Clear the message
-            memset(&g_bridge_msg_pkt, 0, ROS2_TOPIC_NAME_LNGTH+BODY_DATA_MAX_LNGTH);
+            memset(g_bridge_msg_pkt, 0, sizeof(g_bridge_msg_pkt));
             // set topic name data
             memcpy(&g_bridge_msg_pkt[0], (uint8_t*)&tmp_ptr->ros2_topic_name, ROS2_TOPIC_NAME_LNGTH);
+            // set body data length in network byte order
+            RACS2_BRIDGE_WriteBodyDataLength(g_bridge_msg_pkt + BRIDGE_HEADER_LNGTH,
+                                             tmp_ptr->body_data_length);
             // set body data
-            memcpy(&g_bridge_msg_pkt[BRIDGE_HEADER_LNGTH], (uint8_t*)&tmp_ptr->body_data, tmp_ptr->body_data_length);
+            memcpy(&g_bridge_msg_pkt[BODY_DATA_OFFSET], (uint8_t*)&tmp_ptr->body_data,
+                   tmp_ptr->body_data_length);
+            g_bridge_msg_pkt_length = BODY_DATA_OFFSET + tmp_ptr->body_data_length;
             g_should_send_msg_pkt = 1;
             pthread_mutex_unlock(&g_bridge_msg_pkt_mutex);
 

--- a/cFS/Bridge/Client_C/apps/racs2_bridge_client/fsw/src/racs2_bridge_msg.h
+++ b/cFS/Bridge/Client_C/apps/racs2_bridge_client/fsw/src/racs2_bridge_msg.h
@@ -4,12 +4,15 @@
 /*
 ** Type definition (websocket data format for racs2 bridge)
 */
-#define BRIDGE_HEADER_LNGTH   32
-#define BODY_DATA_MAX_LNGTH   128
+#define BRIDGE_HEADER_LNGTH       32
+#define BODY_DATA_LENGTH_LNGTH     4
+#define BODY_DATA_MAX_LNGTH      128
+#define BODY_DATA_OFFSET          (BRIDGE_HEADER_LNGTH + BODY_DATA_LENGTH_LNGTH)
 
 typedef struct
 {
     uint8              header[BRIDGE_HEADER_LNGTH];
+    uint8              body_data_length[BODY_DATA_LENGTH_LNGTH];
     uint8              body_data[BODY_DATA_MAX_LNGTH];
 
 }   OS_PACK racs2_bridge_msg_t  ;


### PR DESCRIPTION
## Summary

Standardize the RACS2 binary WebSocket packet format in both directions as:

`[32-byte header] + [4-byte big-endian body_data_length] + [body_data]`

## Changes

- add the 4-byte big-endian length field to ROS2->cFS and cFS->ROS2 frames
- send variable-length cFS WebSocket frames instead of a fixed 160-byte payload
- validate the declared length, 128-byte body limit, exact frame size, and binary frame type
- reject malformed frames before copying or publishing body data
- add a small Python framing module with regression tests
- document the wire format and update both example cases

The application-side ROS2/cFS message representations remain unchanged; the bridge converts their body length to and from the 4-byte wire field.

## Validation

- protocol unit tests: 9 passed, covering body lengths 0, 1, 127 and 128 plus malformed/oversized/text frames
- C framing helper harness passes with `-std=c99 -Wall -Wextra -Werror`
- a cross-language known vector for cFS message ID `0x1894` and body `abc` matches byte-for-byte between the C and Python implementations

Closes #24